### PR TITLE
Add logError method for non-fatal errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Pods
 Build
 *.iml
 .idea
-
+android/.gradle/
+android/local.properties

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ npx cap update ios
 
 2. The Android setup process (see below) seems a bit complicated for a plugin.  The app-side configuration that is required is somewhat redundant of what is configured within the plugin's `build.gradle` - see [here](https://github.com/josh-m-sharpe/capacitor-firebase-crashlytics/blob/master/android/build.gradle).  However, this is the simplest way to get `com.crashlytics.android.Crashlytics` loaded within the plugin that I was able to figure out. Pull Requests or suggestions to improve the situation are welcome.
 
+3. The Crashlytics setup for android requires something to be put into the app level `build.gradle` file, but Capacitor apps only have a root level `build.gradle` file so this was not possible. The workaround was
+[this stackoverflow answer](https://stackoverflow.com/a/55737238/10129713). If there is a better solution 
+please create a pull request.
+
 ## Usage
 
 Load the module:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ FirebaseCrashlytics.logUser({
 .then(() => alert(`user logged`))
 .catch(err => alert(err.message));
 ```
+
+Log a non-fatal error:
+```typescript
+FirebaseCrashlytics.logError({
+ message: "api returned a 404",
+ domain: "API_ERROR", // Used to group errors together in Crashlytics. Only applies to iOS.
+});
+.then(() => alert(`non-fatal event logged`))
+.catch(err => alert(err.message));
+```
 ## Android setup
 
 1. Follow the [Firebase Crashlytics Get Started guide](https://firebase.google.com/docs/crashlytics/get-started?platform=android) and put your `google-services.json` here: `android/app/google-services.json`

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,12 @@ android {
     }
 }
 
+allprojects {
+    repositories {
+       google()
+    }
+}
+
 repositories {
     google()
     jcenter()
@@ -49,4 +55,3 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
 }
-

--- a/android/src/main/java/com/jsharpe/capacitorfirebasecrashlytics/FirebaseCrashlytics.java
+++ b/android/src/main/java/com/jsharpe/capacitorfirebasecrashlytics/FirebaseCrashlytics.java
@@ -48,5 +48,24 @@ public class FirebaseCrashlytics extends Plugin {
 
          call.success();
      }
+
+     @PluginMethod()
+     public void logError(PluginCall call) {
+         String errorMessage = call.getString("error");
+         String errorDomain = call.getString("domain");
+
+         if (errorMessage == null) {
+             call.reject("missing error property");
+         }
+
+         if (errorDomain == null) {
+             call.reject("missing domain property");
+         }
+
+         Exception ex = new Exception(errorMessage);
+         Crashlytics.logException(ex);
+
+         call.success();
+     }
 }
 

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="my_string">Just a simple string</string>
+    <string name="com.crashlytics.RequireBuildId">false</string>
 </resources>

--- a/ios/Plugin.xcodeproj/project.pbxproj
+++ b/ios/Plugin.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 				50ADFF84201F53D600D50D53 /* Frameworks */,
 				50ADFF85201F53D600D50D53 /* Headers */,
 				50ADFF86201F53D600D50D53 /* Resources */,
+				24389335238707A8006CE4CD /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -255,6 +256,23 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		24389335238707A8006CE4CD /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${PODS_ROOT}/Fabric/run\"\n";
 		};
 		AB5B3E54B4E897F32C2279DA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -6,4 +6,5 @@
 CAP_PLUGIN(FirebaseCrashlytics, "FirebaseCrashlytics",
            CAP_PLUGIN_METHOD(crash, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(logUser, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(logError, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -9,11 +9,11 @@ import Crashlytics
  */
 @objc(FirebaseCrashlytics)
 public class FirebaseCrashlytics: CAPPlugin {
-
+  
   @objc func crash(_ call: CAPPluginCall) {
     Crashlytics.sharedInstance().crash()
   }
-
+  
   @objc func logUser(_ call: CAPPluginCall) {
     guard let email = call.getString("email") else {
       call.error("missing email property")
@@ -27,11 +27,32 @@ public class FirebaseCrashlytics: CAPPlugin {
       call.error("missing name property")
       return
     }
-
+    
     Crashlytics.sharedInstance().setUserEmail(email)
     Crashlytics.sharedInstance().setUserIdentifier(id)
     Crashlytics.sharedInstance().setUserName(name)
-
+    
+    call.success()
+  }
+  
+  @objc func logError(_ call: CAPPluginCall) {
+    guard let errorMessage = call.getString("error") else {
+      call.reject("missing error property")
+      return
+    }
+    
+    guard let errorDomain = call.getString("domain") else {
+      call.reject("missing domain property")
+      return
+    }
+    
+    let userInfo: [String : Any] = [
+      NSLocalizedDescriptionKey: NSLocalizedString("Error", value: errorMessage, comment: "")
+    ]
+    
+    let err = NSError(domain: errorDomain, code: 1000, userInfo: userInfo)
+    Crashlytics.sharedInstance().recordError(err)
+    
     call.success()
   }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -10,7 +10,15 @@ export type CrashlyticsUserOptions = {
   name: string;
 };
 
+export type CrashlyticsErrorOptions = {
+  /** The error message associated with this event */
+  error: string;
+  /** The error domain used to group events in Crashlytics */
+  domain: string;
+};
+
 export interface FirebaseCrashlyticsPlugin {
   crash(): Promise<void>;
   logUser(options: CrashlyticsUserOptions): Promise<void>;
+  logError(options: CrashlyticsErrorOptions): Promise<void>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,5 +1,5 @@
-import { WebPlugin } from '@capacitor/core';
-import { FirebaseCrashlyticsPlugin, CrashlyticsUserOptions } from './definitions';
+import { registerWebPlugin, WebPlugin } from '@capacitor/core';
+import { CrashlyticsErrorOptions, CrashlyticsUserOptions, FirebaseCrashlyticsPlugin } from './definitions';
 
 export class FirebaseCrashlyticsWeb extends WebPlugin implements FirebaseCrashlyticsPlugin {
   constructor() {
@@ -17,11 +17,15 @@ export class FirebaseCrashlyticsWeb extends WebPlugin implements FirebaseCrashly
     console.warn("Crashlytics.logUser is not implemented on web");
     console.log(options);
   }
+
+  async logError(options: CrashlyticsErrorOptions): Promise<void> {
+    console.warn("Crashlytics.logError is not implemented on web");
+    console.log(options);
+  }
 }
 
 const FirebaseCrashlytics = new FirebaseCrashlyticsWeb();
 
 export { FirebaseCrashlytics };
 
-import { registerWebPlugin } from '@capacitor/core';
 registerWebPlugin(FirebaseCrashlytics);


### PR DESCRIPTION
This PR adds a `logError` method that accepts an `error` message and a `domain` that is used for grouping similar errors together in Crashlytics.

Neither Android or iOS were working before this PR. I had to add a build phase script to iOS (outlined in the Crashlytics setup instructions) and use a hacky workaround for Android (see the stackoverflow link in the README).

Also, this plugin is not yet published on npm. Not sure if you were aware.